### PR TITLE
feat: update benchmark to work with new dolphjs update

### DIFF
--- a/benchmarks/middleware.js
+++ b/benchmarks/middleware.js
@@ -24,7 +24,7 @@ while (n--) {
       });
     }
   }
-  server = new Dolph([new TestRouter()], 3100, 'test', { mongodbConfig: null });
+  server = new Dolph([new TestRouter()], 3100, 'test', { mongodbConfig: null }, []);
 }
 
 class TestRouter {
@@ -43,6 +43,6 @@ class TestRouter {
   }
 }
 
-server = new Dolph([new TestRouter()], 3100, 'test', { mongodbConfig: null });
+server = new Dolph([new TestRouter()], 3100, 'test', { mongodbConfig: null }, []);
 
 server.listen();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolphjs/core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "dolph is a light-weight fast express sugar-coat library for making software development faster ",
   "type": "commonjs",
   "maintainers": [


### PR DESCRIPTION
Updated benchmark file to add the middleware option for the Dolph class initialization. This was missing because the file wasn't updated after a major update in the dolphjs  package